### PR TITLE
Add environment and its child subcommands

### DIFF
--- a/cmd/cca/cca.go
+++ b/cmd/cca/cca.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cloud-ca/cca/cmd/cca/completion"
 	"github.com/cloud-ca/cca/cmd/cca/connection"
+	"github.com/cloud-ca/cca/cmd/cca/environment"
 	"github.com/cloud-ca/cca/cmd/cca/version"
 	"github.com/cloud-ca/cca/pkg/cli"
 	"github.com/cloud-ca/cca/pkg/client"
@@ -60,6 +61,7 @@ func NewCommand() *cobra.Command {
 
 	cmd.AddCommand(completion.NewCommand(cli))
 	cmd.AddCommand(connection.NewCommand(cli))
+	cmd.AddCommand(environment.NewCommand(cli))
 	cmd.AddCommand(version.NewCommand(cli))
 
 	return cmd

--- a/cmd/cca/environment/delete/delete.go
+++ b/cmd/cca/environment/delete/delete.go
@@ -1,0 +1,62 @@
+// Copyright © 2019 cloud.ca Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package delete implements the `environment delete` command
+package delete
+
+import (
+	"github.com/cloud-ca/cca/pkg/cli"
+	"github.com/cloud-ca/cca/pkg/output"
+	"github.com/cloud-ca/cca/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+type flag struct {
+	id string
+}
+
+// NewCommand returns a new cobra.Command for environment delete
+func NewCommand(cli *cli.Wrapper) *cobra.Command {
+	flg := &flag{}
+	cmd := &cobra.Command{
+		Args:  cobra.NoArgs,
+		Use:   "delete",
+		Short: "Delete a specific environment",
+		Long: util.LongDescription(`
+            Delete a specific environment. You will need a role with the Delete an existing environment
+            permission to execute this operation.
+        `),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			deleted, err := cli.CcaClient.Environments.Delete(flg.id)
+			if err != nil {
+				return err
+			}
+			return cli.OutputBuilder.Build(func(formatter *output.Formatter) error {
+				type R struct {
+					Deleted bool `json:"deleted"`
+				}
+				return formatter.Format(&R{Deleted: deleted})
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&flg.id, "id", "", "ID of environment to delete")
+
+	err := cmd.MarkFlagRequired("id")
+	if err != nil {
+		panic(err)
+	}
+
+	return cmd
+}

--- a/cmd/cca/environment/environment.go
+++ b/cmd/cca/environment/environment.go
@@ -1,0 +1,42 @@
+// Copyright © 2019 cloud.ca Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package environment implements the `environment` command
+package environment
+
+import (
+	"github.com/cloud-ca/cca/pkg/cli"
+	"github.com/cloud-ca/cca/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// NewCommand returns a new cobra.Command for environment actions
+func NewCommand(cli *cli.Wrapper) *cobra.Command {
+	cmd := &cobra.Command{
+		Args:    cobra.NoArgs,
+		Aliases: []string{"env"},
+		Use:     "environment",
+		Short:   "Manage resources of a specific service and users’ access to them",
+		Long: util.LongDescription(`
+            Environments allow you to manage resources of a specific service and to manage your users’
+            access to them. With environment roles, you have tight control of what a user is allowed to
+            do in your environment. A general use case of environments is to split your resources into
+            different deployment environments (e.g. dev, staging and production). The advantage is that
+            resources of different deployments are isolated from each other and you can restrict user
+            access to your most critical resources.
+        `),
+	}
+
+	return cmd
+}

--- a/cmd/cca/environment/environment.go
+++ b/cmd/cca/environment/environment.go
@@ -16,6 +16,7 @@
 package environment
 
 import (
+	"github.com/cloud-ca/cca/cmd/cca/environment/list"
 	"github.com/cloud-ca/cca/pkg/cli"
 	"github.com/cloud-ca/cca/pkg/util"
 	"github.com/spf13/cobra"
@@ -37,6 +38,8 @@ func NewCommand(cli *cli.Wrapper) *cobra.Command {
             access to your most critical resources.
         `),
 	}
+
+	cmd.AddCommand(list.NewCommand(cli))
 
 	return cmd
 }

--- a/cmd/cca/environment/environment.go
+++ b/cmd/cca/environment/environment.go
@@ -16,6 +16,7 @@
 package environment
 
 import (
+	"github.com/cloud-ca/cca/cmd/cca/environment/delete"
 	"github.com/cloud-ca/cca/cmd/cca/environment/list"
 	"github.com/cloud-ca/cca/pkg/cli"
 	"github.com/cloud-ca/cca/pkg/util"
@@ -39,6 +40,7 @@ func NewCommand(cli *cli.Wrapper) *cobra.Command {
         `),
 	}
 
+	cmd.AddCommand(delete.NewCommand(cli))
 	cmd.AddCommand(list.NewCommand(cli))
 
 	return cmd

--- a/cmd/cca/environment/list/list.go
+++ b/cmd/cca/environment/list/list.go
@@ -1,0 +1,48 @@
+// Copyright © 2019 cloud.ca Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package list implements the `environment list` command
+package list
+
+import (
+	"github.com/cloud-ca/cca/pkg/cli"
+	"github.com/cloud-ca/cca/pkg/output"
+	"github.com/cloud-ca/cca/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// NewCommand returns a new cobra.Command for environment list
+func NewCommand(cli *cli.Wrapper) *cobra.Command {
+	cmd := &cobra.Command{
+		Args:    cobra.NoArgs,
+		Aliases: []string{"ls"},
+		Use:     "list",
+		Short:   "List environments that you have access to",
+		Long: util.LongDescription(`
+            List environments that you have access to. It will only return environments that you’re
+            member of if you’re not assigned the Environments read permission.
+        `),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			envs, err := cli.CcaClient.Environments.List()
+			if err != nil {
+				return err
+			}
+			return cli.OutputBuilder.Build(func(formatter *output.Formatter) error {
+				return formatter.Format(envs)
+			})
+		},
+	}
+
+	return cmd
+}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/cloud-ca/cca/tree/master/CONTRIBUTING.md).

### Description

This PR adds `environment` command and all its subcommands. Including:

- `create`
- `delete`
- `list`
- `update`

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into all boxes that apply:

- [x] I have read the [Contributing Guidelines](https://github.com/cloud-ca/cca/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [ ] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [x] My code follows the code style of this project.
- [x] All checks pass when I run `make checkfmt` and `make lint`.
