### PR TITLE
Add service connection and its child subcommands

### DIFF
--- a/cmd/cca/cca.go
+++ b/cmd/cca/cca.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"github.com/cloud-ca/cca/cmd/cca/completion"
+	"github.com/cloud-ca/cca/cmd/cca/connection"
 	"github.com/cloud-ca/cca/cmd/cca/version"
 	"github.com/cloud-ca/cca/pkg/cli"
 	"github.com/cloud-ca/cca/pkg/client"
@@ -59,6 +60,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&flg.LogLevel, "loglevel", flags.DefaultLogLevel.String(), "log level "+logutil.LevelsString())
 
 	cmd.AddCommand(completion.NewCommand(cli))
+	cmd.AddCommand(connection.NewCommand(cli))
 	cmd.AddCommand(version.NewCommand(cli))
 
 	return cmd

--- a/cmd/cca/connection/connection.go
+++ b/cmd/cca/connection/connection.go
@@ -1,0 +1,38 @@
+// Copyright © 2019 cloud.ca Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package connection implements the `connection` command
+package connection
+
+import (
+	"github.com/cloud-ca/cca/pkg/cli"
+	"github.com/cloud-ca/cca/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// NewCommand returns a new cobra.Command for connection
+func NewCommand(cli *cli.Wrapper) *cobra.Command {
+	cmd := &cobra.Command{
+		Args:  cobra.NoArgs,
+		Use:   "connection",
+		Short: "Manage service connections that you can create resources for",
+		Long: util.LongDescription(`
+            Service connections are the services that you can create resources for (e.g. compute, object
+            storage). Environments are created for a specific service which allows you to create and
+            manage resources within that service.
+        `),
+	}
+
+	return cmd
+}

--- a/cmd/cca/connection/get/get.go
+++ b/cmd/cca/connection/get/get.go
@@ -12,32 +12,41 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package connection implements the `connection` command
-package connection
+// Package get implements the `connection get` command
+package get
 
 import (
-	"github.com/cloud-ca/cca/cmd/cca/connection/get"
-	"github.com/cloud-ca/cca/cmd/cca/connection/list"
 	"github.com/cloud-ca/cca/pkg/cli"
-	"github.com/cloud-ca/cca/pkg/util"
+	"github.com/cloud-ca/cca/pkg/output"
 	"github.com/spf13/cobra"
 )
 
-// NewCommand returns a new cobra.Command for connection
+type flag struct {
+	id string
+}
+
+// NewCommand returns a new cobra.Command for connection get
 func NewCommand(cli *cli.Wrapper) *cobra.Command {
+	flg := &flag{}
 	cmd := &cobra.Command{
 		Args:  cobra.NoArgs,
-		Use:   "connection",
-		Short: "Manage service connections that you can create resources for",
-		Long: util.LongDescription(`
-            Service connections are the services that you can create resources for (e.g. compute, object
-            storage). Environments are created for a specific service which allows you to create and
-            manage resources within that service.
-        `),
+		Use:   "get",
+		Short: "Get service connection",
+		Long:  "Get service connection",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			connection, err := cli.CcaClient.ServiceConnections.Get(flg.id)
+			if err != nil {
+				return err
+			}
+			return cli.OutputBuilder.Build(func(formatter *output.Formatter) error {
+				return formatter.Format(connection)
+			})
+		},
 	}
 
-	cmd.AddCommand(get.NewCommand(cli))
-	cmd.AddCommand(list.NewCommand(cli))
+	cmd.Flags().StringVar(&flg.id, "id", "", "environment id")
+
+	cmd.MarkFlagRequired("id")
 
 	return cmd
 }

--- a/cmd/cca/connection/get/get.go
+++ b/cmd/cca/connection/get/get.go
@@ -46,7 +46,10 @@ func NewCommand(cli *cli.Wrapper) *cobra.Command {
 
 	cmd.Flags().StringVar(&flg.id, "id", "", "environment id")
 
-	cmd.MarkFlagRequired("id")
+	err := cmd.MarkFlagRequired("id")
+	if err != nil {
+		panic(err)
+	}
 
 	return cmd
 }

--- a/cmd/cca/connection/list/list.go
+++ b/cmd/cca/connection/list/list.go
@@ -12,30 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package connection implements the `connection` command
-package connection
+// Package list implements the `connection list` command
+package list
 
 import (
-	"github.com/cloud-ca/cca/cmd/cca/connection/list"
 	"github.com/cloud-ca/cca/pkg/cli"
-	"github.com/cloud-ca/cca/pkg/util"
+	"github.com/cloud-ca/cca/pkg/output"
 	"github.com/spf13/cobra"
 )
 
-// NewCommand returns a new cobra.Command for connection
+// NewCommand returns a new cobra.Command for connection list
 func NewCommand(cli *cli.Wrapper) *cobra.Command {
 	cmd := &cobra.Command{
-		Args:  cobra.NoArgs,
-		Use:   "connection",
-		Short: "Manage service connections that you can create resources for",
-		Long: util.LongDescription(`
-            Service connections are the services that you can create resources for (e.g. compute, object
-            storage). Environments are created for a specific service which allows you to create and
-            manage resources within that service.
-        `),
+		Args:    cobra.NoArgs,
+		Aliases: []string{"ls"},
+		Use:     "list",
+		Short:   "List all service connections",
+		Long:    "List all service connections",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			connections, err := cli.CcaClient.ServiceConnections.List()
+			if err != nil {
+				return err
+			}
+			return cli.OutputBuilder.Build(func(formatter *output.Formatter) error {
+				return formatter.Format(connections)
+			})
+		},
 	}
-
-	cmd.AddCommand(list.NewCommand(cli))
 
 	return cmd
 }


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/cloud-ca/cca/tree/master/CONTRIBUTING.md).

### Description

This PR adds `connection` commands and all its subcommands, including:

- `get`
- `list`

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/cloud-ca/cca/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [ ] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [x] My code follows the code style of this project.
- [x] All checks pass when I run `make checkfmt` and `make lint`.
